### PR TITLE
Update font-lock to improve look-and-feel

### DIFF
--- a/heex-ts-mode.el
+++ b/heex-ts-mode.el
@@ -1,3 +1,4 @@
+
 ;;; heex-ts-mode.el --- Major mode for Heex with tree-sitter support -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2022-2024 Wilhelm H Kirschbaum
@@ -103,13 +104,13 @@
      `([(tag_name) (slot_name)] @font-lock-function-name-face)
      :language 'heex
      :feature 'heex-attribute
-     `((attribute_name) @font-lock-variable-name-face)
+     `((attribute_name) @font-lock-type-face)
      :language 'heex
      :feature 'heex-keyword
      `((special_attribute_name) @font-lock-keyword-face)
      :language 'heex
      :feature 'heex-string
-     `([(attribute_value) (quoted_attribute_value)] @font-lock-constant-face)
+     `([(attribute_value) (quoted_attribute_value)] @font-lock-string-face)
      :language 'heex
      :feature 'heex-component
      `([


### PR DESCRIPTION
Hello @wkirschbaum , hope you are doing well. I came up with an opinionated change to improve optical perception and visual improvement in general of a color scheme I use (it is doom-theme one-light, but it seems the issue with other themes as well). The color palettes seems has almost the same shade of violet, which is a little bit annoying:

![Screenshot from 2024-09-16 11-51-59](https://github.com/user-attachments/assets/2d525f81-4840-410c-b355-346d7c18db64)

If a patch will be applied it will look like:

![Screenshot from 2024-09-16 11-53-15](https://github.com/user-attachments/assets/aba8e108-91b9-4e3d-bb54-0886da93df80)

Thank you,
Illia
