### PR TITLE
Fix typo affecting customization group

### DIFF
--- a/heex-ts-mode.el
+++ b/heex-ts-mode.el
@@ -41,7 +41,7 @@
 (defgroup heex-ts nil
   "Major mode for editing HEEx code."
   :prefix "heex-ts-"
-  :group 'langauges)
+  :group 'languages)
 
 (defcustom heex-ts-indent-offset 2
   "Indentation of HEEx statements."


### PR DESCRIPTION
The typo results in heex-ts being classified under "langauges" instead of "languages" when using `M-x customize` or `M-x customize-group`.